### PR TITLE
Add conditional display

### DIFF
--- a/src/scripts/cf/form-tags/TagGroup.ts
+++ b/src/scripts/cf/form-tags/TagGroup.ts
@@ -53,8 +53,15 @@ namespace cf {
 		}
 
 		public get value (): string{
-			// TODO: fix value???
-			return "";
+			const valuesChecked = new Array();
+			this.elements.forEach((element) => {
+				let domElement = <HTMLInputElement>element.domElement;
+				if(domElement.checked) {
+					valuesChecked.push(domElement.value);
+				}
+			});
+
+			return valuesChecked.join('|');
 		}
 		
 		public get errorMessage():string{
@@ -144,6 +151,14 @@ namespace cf {
 			}
 
 			return isValid;
+		}
+
+		public shouldBeDisplayed(previousTags: Array<ITag>): boolean {
+			this.elements = this.elements.filter((element) => {
+				return element.shouldBeDisplayed(previousTags);
+			});
+
+			return (this.elements.length > 0);
 		}
 	}
 }

--- a/src/scripts/cf/logic/FlowManager.ts
+++ b/src/scripts/cf/logic/FlowManager.ts
@@ -105,7 +105,12 @@ namespace cf {
 			if(this.step == this.maxSteps){
 				// console.warn("We are at the end..., submit click")
 				this.cuiReference.doSubmitForm();
-			}else{
+			} else if(!this.shouldStepBeDisplayed()) {
+				this.tags.splice(this.step, 1); // we remove the current step
+				this.maxSteps--; // we remove one step for the total steps
+				this.step--; // we go back to the previous step
+				this.nextStep(); // we ask for a next step
+			} else {
 				this.step %= this.maxSteps;
 				this.showStep();
 			}
@@ -117,6 +122,10 @@ namespace cf {
 			document.dispatchEvent(new CustomEvent(FlowEvents.FLOW_UPDATE, {
 				detail: this.currentTag
 			}));
+		}
+
+		private shouldStepBeDisplayed(): boolean {
+			return this.currentTag.shouldBeDisplayed(this.tags.slice(0, this.step));
 		}
 	}
 }


### PR DESCRIPTION
## Intro
Hi, I'm developing this to help people (like me) encountering the _issue_ [with conditional display](https://github.com/space10-community/conversational-form/issues/18).

So my solution is a bit different since my last post.

I decided to create an attribute `cf-display-if` which can take something like this.
* `NAME_OF_AN_INPUT_TAG == 'value1' AND NAME_OF_AN_INPUT_TAG == 'value2'`
* `NAME_OF_AN_INPUT_TAG == 'value1' OR NAME_OF_AN_INPUT_TAG == 'value2' AND NAME_OF_AN_INPUT_TAG == 'value3'`
* `NAME_OF_AN_INPUT_TAG CONTAINS ('value1')`

Then this syntax is parsed to a javascript expression which will be evaluated when a tag containing this attribute is displayed.

## How can I test this feature ? 

If you want to test it and see if it works I created an example here on pastebin.
Just build CF from sources and copy paste this [pastebin](http://pastebin.com/ugYqCA1S) on **/test/custom-form.html**

*I also upload an example online right here : http://cf-conditional.surge.sh/*
Thanks to awesome surge service.

## What's next ? 
If you agree with my solution, want some information, or want modifications on it. Please post a comment and I'll try to answer you as fast as I can.
When/If my modification is ready to be merged I'll be glad to write more documentation (about the syntax) on the readme.

Thanks in advance.