### PR TITLE
Fix typos

### DIFF
--- a/docs/0.9.70/public-api/index.html
+++ b/docs/0.9.70/public-api/index.html
@@ -18,12 +18,12 @@
 	<meta name="twitter:creator" content="@space10_journal">
 	<meta name="twitter:title" content="Turning web forms into conversations"/>
 	<meta name="twitter:description" content="Conversational Form is an open-source concept by SPACE10 to easily turn any form element on a web page into a conversational form interface."/>
-	<meta name="twitter:image" content="https://space10-community.github.io/conversational-form/docs/0.9.70/assets/share_img.jpg" />
+	<meta name="twitter:image" content="https://space10-community.github.io/conversational-form/docs/1.0.0/assets/share_img.jpg" />
 
 	<!-- Open Graph data -->
 	<meta property="og:title" content="Turning web forms into conversations"/>
 	<meta property="og:type" content="article"/>
-	<meta property="og:image" content="https://space10-community.github.io/conversational-form/docs/0.9.70/assets/share_img.jpg" />
+	<meta property="og:image" content="https://space10-community.github.io/conversational-form/docs/1.0.0/assets/share_img.jpg" />
 
 				
 	<link href="../assets/prism.css" rel="stylesheet" />
@@ -57,9 +57,6 @@
 
   <div class="navbar-nav-scroll">
     <ul class="navbar-nav cfddoc-navbar-nav flex-row">
-
-      
-      
       <li>
         <button class="btn btn-link bd-search-docs-toggle d-md-none p-0 ml-3" type="button" data-toggle="collapse" data-target="#cfdoc-links" aria-controls="cfdoc-links" aria-expanded="false" aria-label="Toggle docs navigation">
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 30" width="30" height="30" focusable="false"><title>Menu</title><path stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-miterlimit="10" d="M4 7h22M4 15h22M4 23h22"></path></svg>
@@ -70,7 +67,23 @@
   </div>
 
   <ul class="navbar-nav flex-row ml-md-auto d-none d-md-flex">
-    
+    <li class="nav-item dropdown">
+      <a class="nav-item nav-link dropdown-toggle mr-md-2" href="#" id="cfdoc-versions" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+        v1.0.0
+      </a>
+      <div class="dropdown-menu dropdown-menu-right" aria-labelledby="cfdoc-versions">
+                	<a class="dropdown-item active" href="../../1.0.0/">v1.0.0</a>
+                	<a class="dropdown-item" href="../../0.9.90/">v0.9.90</a>
+                	<a class="dropdown-item" href="../../0.9.80/">v0.9.80</a>
+                	<a class="dropdown-item" href="../../0.9.71/">v0.9.71</a>
+                	<a class="dropdown-item" href="../../0.9.70/">v0.9.70</a>
+              </div>
+    </li>
+    <li class="nav-item">
+      <a class="nav-link" href="https://github.com/space10-community/conversational-form" target="_blank" rel="noopener" aria-label="GitHub">
+        <svg class="navbar-nav-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 499.36" focusable="false"><title>GitHub</title><path d="M256 0C114.64 0 0 114.61 0 256c0 113.09 73.34 209 175.08 242.9 12.8 2.35 17.47-5.56 17.47-12.34 0-6.08-.22-22.18-.35-43.54-71.2 15.49-86.2-34.34-86.2-34.34-11.64-29.57-28.42-37.45-28.42-37.45-23.27-15.84 1.73-15.55 1.73-15.55 25.69 1.81 39.21 26.38 39.21 26.38 22.84 39.12 59.92 27.82 74.5 21.27 2.33-16.54 8.94-27.82 16.25-34.22-56.84-6.43-116.6-28.43-116.6-126.49 0-27.95 10-50.8 26.35-68.69-2.63-6.48-11.42-32.5 2.51-67.75 0 0 21.49-6.88 70.4 26.24a242.65 242.65 0 0 1 128.18 0c48.87-33.13 70.33-26.24 70.33-26.24 14 35.25 5.18 61.27 2.55 67.75 16.41 17.9 26.31 40.75 26.31 68.69 0 98.35-59.85 120-116.88 126.32 9.19 7.9 17.38 23.53 17.38 47.41 0 34.22-.31 61.83-.31 70.23 0 6.85 4.61 14.81 17.6 12.31C438.72 464.97 512 369.08 512 256.02 512 114.62 397.37 0 256 0z" fill="#fff" fill-rule="evenodd"></path></svg>
+      </a>
+    </li>
     <li class="nav-item">
         <a class="nav-link " href="https://space10.io/" target="_blank">
           <svg width="73" height="12" viewBox="0 0 73 12" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><title>space10</title><defs><path id="a" d="M11.894 9.996H0V0h11.894v9.996z"/><path id="c" d="M0 0h11.8v9.146H0z"/></defs><g fill="none" fill-rule="evenodd"><g transform="rotate(90 4.996 4.996)"><mask id="b" fill="#fff"><use xlink:href="#a"/></mask><path d="M7.818 7.003c1.343-.065 1.775-.902 1.775-2.174 0-.901-.32-1.835-1.167-1.835-1.008 0-1.2 1.642-1.663 3.3-.464 1.641-1.2 3.364-3.294 3.364C.976 9.658 0 7.131 0 4.973 0 2.688 1.103.385 3.677.37v2.994c-1.038-.049-1.375.934-1.375 1.852 0 .644.224 1.448.975 1.448.88 0 1.04-1.657 1.504-3.332C5.244 1.675 6.01 0 8.074 0c2.894 0 3.82 2.48 3.82 5.007 0 2.639-1.15 4.974-4.076 4.99V7.003z" fill="#FFF" mask="url(#b)"/></g><path d="M11.37 0h5.458c2.14 0 4.153.974 4.153 3.677 0 2.83-1.626 3.933-4.153 3.933h-2.463v3.806H11.37V0zm2.995 5.308h2.013c.932 0 1.609-.383 1.609-1.424 0-1.07-.692-1.503-1.61-1.503h-2.012v2.927zM24.718 0h3.042l4.298 11.416h-3.124l-.708-2.046H24.22l-.725 2.046h-3.075L24.718 0zm.193 7.163h2.607l-1.27-3.997h-.033L24.91 7.163zM40.14 4.318c-.16-1.152-1.061-1.76-2.318-1.76-1.932 0-2.671 1.695-2.671 3.39s.74 3.39 2.671 3.39c1.402 0 2.206-.799 2.319-2.11h2.994c-.161 2.94-2.335 4.668-5.248 4.668-3.478 0-5.731-2.64-5.731-5.949C32.156 2.64 34.409 0 37.887 0c2.48 0 5.168 1.567 5.248 4.318H40.14zM44.891 0h9.16v2.38h-6.166v2h5.635v2.303h-5.635v2.174h6.327v2.559h-9.32zM55.088 4.3V2.303c1.576.032 3.203-.543 3.316-2.302h2.27v11.416h-2.898V4.3h-2.688z" fill="#FFF"/><g transform="rotate(90 36.267 36.267)"><mask id="d" fill="#fff"><use xlink:href="#c"/></mask><path d="M5.89 9.146C2.822 9.146 0 7.954 0 4.665 0 1.275 2.821 0 5.89 0c3.072 0 5.91 1.275 5.91 4.665 0 3.289-2.838 4.481-5.91 4.481m0-6.53c-1.5 0-3.614.105-3.614 1.966 0 1.794 2.114 1.947 3.615 1.947 1.502 0 3.63-.153 3.63-1.947 0-1.861-2.128-1.966-3.63-1.966" fill="#FFF" mask="url(#d)"/></g></g></svg>
@@ -100,7 +113,7 @@
 							<a class="toc-link" href="../events/">Events</a>
 													</div>
 																																				<div class="toc-item">
-							<a class="toc-link" href="../functionality/conditionals-and-branching/">Functionality</a>
+							<a class="toc-link" href="../functionality/autocomplete/">Functionality</a>
 													</div>
 																																				<div class="toc-item">
 							<a class="toc-link" href="../integrations/">Integrations</a>
@@ -119,15 +132,12 @@
 			</div>
 			
 			<main class="col-12 col-md-9 col-xl-8 py-md-3 pl-md-5" role="main">
-				<div class="alert alert-success mt-3" role="alert">
-					Version 1.0 has been released - See the <a href="https://space10-community.github.io/conversational-form/docs/">updated documentation</a>.
-				</div>
 				    <h1 id="public-api">Public API</h1>
     <p>When instantiating ConversationalForm a reference to the instance will be available in window scope.</p>
     
 	<pre><code class="language-javascript" data-lang="javascript">window.ConversationalForm</code></pre>
 	
-	<p>Be aware that if you create mutiple Conversational Forms within one page then the reference will be overwritten with latest created. Use windo.ConversationalForm[form["cf-create-id"]]?` or just manually instantiate the form and user the returned instance.</p>
+	<p>Be aware that if you create mutiple Conversational Forms within one page then the reference will be overwritten with latest created. Use window.ConversationalForm[form["cf-create-id"]]? or just manually instantiate the form and user the returned instance.</p>
 	
 	<table class="table compact">
     	<thead>
@@ -148,11 +158,6 @@
     		</tr>
 			<tr>
     			<td id="addTags">focus</td>
-    			<td>Sets focus on Conversational Form.</td>
-    			<td><pre><code class="language-javascript" data-lang="javascript">window.ConversationalForm.focus();</pre></code></td>
-    		</tr>
-    		<tr>
-    			<td id="focus">focus</td>
     			<td>Sets focus on Conversational Form.</td>
     			<td><pre><code class="language-javascript" data-lang="javascript">window.ConversationalForm.focus();</pre></code></td>
     		</tr>

--- a/docs/0.9.70/public-api/index.html
+++ b/docs/0.9.70/public-api/index.html
@@ -137,7 +137,7 @@
     
 	<pre><code class="language-javascript" data-lang="javascript">window.ConversationalForm</code></pre>
 	
-	<p>Be aware that if you create mutiple Conversational Forms within one page then the reference will be overwritten with latest created. Use window.ConversationalForm[form["cf-create-id"]]? or just manually instantiate the form and user the returned instance.</p>
+	<p>Be aware that if you create multiple Conversational Forms within one page then the reference will be overwritten with the latest created. Use window.ConversationalForm[form["cf-create-id"]]? or just manually instantiate the form and user the returned instance.</p>
 	
 	<table class="table compact">
     	<thead>

--- a/docs/0.9.71/public-api/index.html
+++ b/docs/0.9.71/public-api/index.html
@@ -18,12 +18,12 @@
 	<meta name="twitter:creator" content="@space10_journal">
 	<meta name="twitter:title" content="Turning web forms into conversations"/>
 	<meta name="twitter:description" content="Conversational Form is an open-source concept by SPACE10 to easily turn any form element on a web page into a conversational form interface."/>
-	<meta name="twitter:image" content="https://space10-community.github.io/conversational-form/docs/0.9.71/assets/share_img.jpg" />
+	<meta name="twitter:image" content="https://space10-community.github.io/conversational-form/docs/1.0.0/assets/share_img.jpg" />
 
 	<!-- Open Graph data -->
 	<meta property="og:title" content="Turning web forms into conversations"/>
 	<meta property="og:type" content="article"/>
-	<meta property="og:image" content="https://space10-community.github.io/conversational-form/docs/0.9.71/assets/share_img.jpg" />
+	<meta property="og:image" content="https://space10-community.github.io/conversational-form/docs/1.0.0/assets/share_img.jpg" />
 
 				
 	<link href="../assets/prism.css" rel="stylesheet" />
@@ -57,9 +57,6 @@
 
   <div class="navbar-nav-scroll">
     <ul class="navbar-nav cfddoc-navbar-nav flex-row">
-
-      
-      
       <li>
         <button class="btn btn-link bd-search-docs-toggle d-md-none p-0 ml-3" type="button" data-toggle="collapse" data-target="#cfdoc-links" aria-controls="cfdoc-links" aria-expanded="false" aria-label="Toggle docs navigation">
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 30" width="30" height="30" focusable="false"><title>Menu</title><path stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-miterlimit="10" d="M4 7h22M4 15h22M4 23h22"></path></svg>
@@ -76,11 +73,16 @@
       </a>
       <div class="dropdown-menu dropdown-menu-right" aria-labelledby="cfdoc-versions">
                 	<a class="dropdown-item active" href="../../1.0.0/">v1.0.0</a>
-                	<a class="dropdown-item active" href="../../0.9.90/">v0.9.90</a>
-                	<a class="dropdown-item active" href="../../0.9.80/">v0.9.80</a>
-                	<a class="dropdown-item active" href="../../0.9.71/">v0.9.71</a>
-                	<a class="dropdown-item active" href="../../0.9.70/">v0.9.70</a>
+                	<a class="dropdown-item" href="../../0.9.90/">v0.9.90</a>
+                	<a class="dropdown-item" href="../../0.9.80/">v0.9.80</a>
+                	<a class="dropdown-item" href="../../0.9.71/">v0.9.71</a>
+                	<a class="dropdown-item" href="../../0.9.70/">v0.9.70</a>
               </div>
+    </li>
+    <li class="nav-item">
+      <a class="nav-link" href="https://github.com/space10-community/conversational-form" target="_blank" rel="noopener" aria-label="GitHub">
+        <svg class="navbar-nav-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 499.36" focusable="false"><title>GitHub</title><path d="M256 0C114.64 0 0 114.61 0 256c0 113.09 73.34 209 175.08 242.9 12.8 2.35 17.47-5.56 17.47-12.34 0-6.08-.22-22.18-.35-43.54-71.2 15.49-86.2-34.34-86.2-34.34-11.64-29.57-28.42-37.45-28.42-37.45-23.27-15.84 1.73-15.55 1.73-15.55 25.69 1.81 39.21 26.38 39.21 26.38 22.84 39.12 59.92 27.82 74.5 21.27 2.33-16.54 8.94-27.82 16.25-34.22-56.84-6.43-116.6-28.43-116.6-126.49 0-27.95 10-50.8 26.35-68.69-2.63-6.48-11.42-32.5 2.51-67.75 0 0 21.49-6.88 70.4 26.24a242.65 242.65 0 0 1 128.18 0c48.87-33.13 70.33-26.24 70.33-26.24 14 35.25 5.18 61.27 2.55 67.75 16.41 17.9 26.31 40.75 26.31 68.69 0 98.35-59.85 120-116.88 126.32 9.19 7.9 17.38 23.53 17.38 47.41 0 34.22-.31 61.83-.31 70.23 0 6.85 4.61 14.81 17.6 12.31C438.72 464.97 512 369.08 512 256.02 512 114.62 397.37 0 256 0z" fill="#fff" fill-rule="evenodd"></path></svg>
+      </a>
     </li>
     <li class="nav-item">
         <a class="nav-link " href="https://space10.io/" target="_blank">
@@ -111,7 +113,7 @@
 							<a class="toc-link" href="../events/">Events</a>
 													</div>
 																																				<div class="toc-item">
-							<a class="toc-link" href="../functionality/conditionals-and-branching/">Functionality</a>
+							<a class="toc-link" href="../functionality/autocomplete/">Functionality</a>
 													</div>
 																																				<div class="toc-item">
 							<a class="toc-link" href="../integrations/">Integrations</a>
@@ -130,15 +132,12 @@
 			</div>
 			
 			<main class="col-12 col-md-9 col-xl-8 py-md-3 pl-md-5" role="main">
-				<div class="alert alert-success mt-3" role="alert">
-					Version 1.0 has been released - See the <a href="https://space10-community.github.io/conversational-form/docs/">updated documentation</a>.
-				</div>
 				    <h1 id="public-api">Public API</h1>
     <p>When instantiating ConversationalForm a reference to the instance will be available in window scope.</p>
     
 	<pre><code class="language-javascript" data-lang="javascript">window.ConversationalForm</code></pre>
 	
-	<p>Be aware that if you create mutiple Conversational Forms within one page then the reference will be overwritten with latest created. Use windo.ConversationalForm[form["cf-create-id"]]?` or just manually instantiate the form and user the returned instance.</p>
+	<p>Be aware that if you create mutiple Conversational Forms within one page then the reference will be overwritten with latest created. Use window.ConversationalForm[form["cf-create-id"]]? or just manually instantiate the form and user the returned instance.</p>
 	
 	<table class="table compact">
     	<thead>
@@ -159,11 +158,6 @@
     		</tr>
 			<tr>
     			<td id="addTags">focus</td>
-    			<td>Sets focus on Conversational Form.</td>
-    			<td><pre><code class="language-javascript" data-lang="javascript">window.ConversationalForm.focus();</pre></code></td>
-    		</tr>
-    		<tr>
-    			<td id="focus">focus</td>
     			<td>Sets focus on Conversational Form.</td>
     			<td><pre><code class="language-javascript" data-lang="javascript">window.ConversationalForm.focus();</pre></code></td>
     		</tr>

--- a/docs/0.9.71/public-api/index.html
+++ b/docs/0.9.71/public-api/index.html
@@ -137,7 +137,7 @@
     
 	<pre><code class="language-javascript" data-lang="javascript">window.ConversationalForm</code></pre>
 	
-	<p>Be aware that if you create mutiple Conversational Forms within one page then the reference will be overwritten with latest created. Use window.ConversationalForm[form["cf-create-id"]]? or just manually instantiate the form and user the returned instance.</p>
+	<p>Be aware that if you create multiple Conversational Forms within one page then the reference will be overwritten with the latest created. Use window.ConversationalForm[form["cf-create-id"]]? or just manually instantiate the form and user the returned instance.</p>
 	
 	<table class="table compact">
     	<thead>

--- a/docs/0.9.80/public-api/index.html
+++ b/docs/0.9.80/public-api/index.html
@@ -18,12 +18,12 @@
 	<meta name="twitter:creator" content="@space10_journal">
 	<meta name="twitter:title" content="Turning web forms into conversations"/>
 	<meta name="twitter:description" content="Conversational Form is an open-source concept by SPACE10 to easily turn any form element on a web page into a conversational form interface."/>
-	<meta name="twitter:image" content="https://space10-community.github.io/conversational-form/docs/0.9.80/assets/share_img.jpg" />
+	<meta name="twitter:image" content="https://space10-community.github.io/conversational-form/docs/1.0.0/assets/share_img.jpg" />
 
 	<!-- Open Graph data -->
 	<meta property="og:title" content="Turning web forms into conversations"/>
 	<meta property="og:type" content="article"/>
-	<meta property="og:image" content="https://space10-community.github.io/conversational-form/docs/0.9.80/assets/share_img.jpg" />
+	<meta property="og:image" content="https://space10-community.github.io/conversational-form/docs/1.0.0/assets/share_img.jpg" />
 
 				
 	<link href="../assets/prism.css" rel="stylesheet" />
@@ -69,12 +69,12 @@
   <ul class="navbar-nav flex-row ml-md-auto d-none d-md-flex">
     <li class="nav-item dropdown">
       <a class="nav-item nav-link dropdown-toggle mr-md-2" href="#" id="cfdoc-versions" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-        v0.9.80
+        v1.0.0
       </a>
       <div class="dropdown-menu dropdown-menu-right" aria-labelledby="cfdoc-versions">
-                	<a class="dropdown-item" href="../../1.0.0/">v1.0.0</a>
+                	<a class="dropdown-item active" href="../../1.0.0/">v1.0.0</a>
                 	<a class="dropdown-item" href="../../0.9.90/">v0.9.90</a>
-                	<a class="dropdown-item active" href="../../0.9.80/">v0.9.80</a>
+                	<a class="dropdown-item" href="../../0.9.80/">v0.9.80</a>
                 	<a class="dropdown-item" href="../../0.9.71/">v0.9.71</a>
                 	<a class="dropdown-item" href="../../0.9.70/">v0.9.70</a>
               </div>
@@ -113,7 +113,7 @@
 							<a class="toc-link" href="../events/">Events</a>
 													</div>
 																																				<div class="toc-item">
-							<a class="toc-link" href="../functionality/conditionals-and-branching/">Functionality</a>
+							<a class="toc-link" href="../functionality/autocomplete/">Functionality</a>
 													</div>
 																																				<div class="toc-item">
 							<a class="toc-link" href="../integrations/">Integrations</a>
@@ -132,15 +132,12 @@
 			</div>
 			
 			<main class="col-12 col-md-9 col-xl-8 py-md-3 pl-md-5" role="main">
-				<div class="alert alert-success mt-3" role="alert">
-					Version 1.0 has been released - See the <a href="https://space10-community.github.io/conversational-form/docs/">updated documentation</a>.
-				</div>
 				    <h1 id="public-api">Public API</h1>
     <p>When instantiating ConversationalForm a reference to the instance will be available in window scope.</p>
     
 	<pre><code class="language-javascript" data-lang="javascript">window.ConversationalForm</code></pre>
 	
-	<p>Be aware that if you create mutiple Conversational Forms within one page then the reference will be overwritten with latest created. Use windo.ConversationalForm[form["cf-create-id"]]?` or just manually instantiate the form and user the returned instance.</p>
+	<p>Be aware that if you create mutiple Conversational Forms within one page then the reference will be overwritten with latest created. Use window.ConversationalForm[form["cf-create-id"]]? or just manually instantiate the form and user the returned instance.</p>
 	
 	<table class="table compact">
     	<thead>
@@ -161,11 +158,6 @@
     		</tr>
 			<tr>
     			<td id="addTags">focus</td>
-    			<td>Sets focus on Conversational Form.</td>
-    			<td><pre><code class="language-javascript" data-lang="javascript">window.ConversationalForm.focus();</pre></code></td>
-    		</tr>
-    		<tr>
-    			<td id="focus">focus</td>
     			<td>Sets focus on Conversational Form.</td>
     			<td><pre><code class="language-javascript" data-lang="javascript">window.ConversationalForm.focus();</pre></code></td>
     		</tr>

--- a/docs/0.9.80/public-api/index.html
+++ b/docs/0.9.80/public-api/index.html
@@ -137,7 +137,7 @@
     
 	<pre><code class="language-javascript" data-lang="javascript">window.ConversationalForm</code></pre>
 	
-	<p>Be aware that if you create mutiple Conversational Forms within one page then the reference will be overwritten with latest created. Use window.ConversationalForm[form["cf-create-id"]]? or just manually instantiate the form and user the returned instance.</p>
+	<p>Be aware that if you create multiple Conversational Forms within one page then the reference will be overwritten with the latest created. Use window.ConversationalForm[form["cf-create-id"]]? or just manually instantiate the form and user the returned instance.</p>
 	
 	<table class="table compact">
     	<thead>

--- a/docs/0.9.90/public-api/index.html
+++ b/docs/0.9.90/public-api/index.html
@@ -18,12 +18,12 @@
 	<meta name="twitter:creator" content="@space10_journal">
 	<meta name="twitter:title" content="Turning web forms into conversations"/>
 	<meta name="twitter:description" content="Conversational Form is an open-source concept by SPACE10 to easily turn any form element on a web page into a conversational form interface."/>
-	<meta name="twitter:image" content="https://space10-community.github.io/conversational-form/docs/0.9.90/assets/share_img.jpg" />
+	<meta name="twitter:image" content="https://space10-community.github.io/conversational-form/docs/1.0.0/assets/share_img.jpg" />
 
 	<!-- Open Graph data -->
 	<meta property="og:title" content="Turning web forms into conversations"/>
 	<meta property="og:type" content="article"/>
-	<meta property="og:image" content="https://space10-community.github.io/conversational-form/docs/0.9.90/assets/share_img.jpg" />
+	<meta property="og:image" content="https://space10-community.github.io/conversational-form/docs/1.0.0/assets/share_img.jpg" />
 
 				
 	<link href="../assets/prism.css" rel="stylesheet" />
@@ -31,9 +31,9 @@
 	
 	<script src="https://cdn.jsdelivr.net/npm/clipboard@1/dist/clipboard.min.js"></script>
 	<script async src="https://production-assets.codepen.io/assets/embed/ei.js"></script>
-	<script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
-	<script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/umd/popper.min.js" integrity="sha384-ZMP7rVo3mIykV+2+9J3UJ46jBk0WLaUAdn689aCwoqbBJiSnjAK/l8WvCWPIPm49" crossorigin="anonymous"></script>
-	<script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js" integrity="sha384-ChfqqxuZUCnJSK3+MXmPNIyE6ZbWh2IMqE241rYiqJxyMiZ6OW/JmZQ5stwEULTy" crossorigin="anonymous"></script>
+	<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.3/umd/popper.min.js" integrity="sha384-vFJXuSJphROIrBnz7yo7oB41mKfc8JzQZiCq4NCceLEaO4IHwicKwpJf9c9IpFgh" crossorigin="anonymous"></script>
+	<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta.2/js/bootstrap.min.js" integrity="sha384-alpBpkh1PFOepccYVYDB4do5UnbKysX5WZXm3XxPqe5iKTfUKjNkCk9SaVuEZflJ" crossorigin="anonymous"></script>
 
 	<script src="../assets/prism.js"></script>
 	<script src="../js/documentation.js"></script>
@@ -69,11 +69,11 @@
   <ul class="navbar-nav flex-row ml-md-auto d-none d-md-flex">
     <li class="nav-item dropdown">
       <a class="nav-item nav-link dropdown-toggle mr-md-2" href="#" id="cfdoc-versions" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-        v0.9.90
+        v1.0.0
       </a>
       <div class="dropdown-menu dropdown-menu-right" aria-labelledby="cfdoc-versions">
-                	<a class="dropdown-item" href="../../1.0.0/">v1.0.0</a>
-                	<a class="dropdown-item active" href="../../0.9.90/">v0.9.90</a>
+                	<a class="dropdown-item active" href="../../1.0.0/">v1.0.0</a>
+                	<a class="dropdown-item" href="../../0.9.90/">v0.9.90</a>
                 	<a class="dropdown-item" href="../../0.9.80/">v0.9.80</a>
                 	<a class="dropdown-item" href="../../0.9.71/">v0.9.71</a>
                 	<a class="dropdown-item" href="../../0.9.70/">v0.9.70</a>
@@ -113,7 +113,7 @@
 							<a class="toc-link" href="../events/">Events</a>
 													</div>
 																																				<div class="toc-item">
-							<a class="toc-link" href="../functionality/conditionals-and-branching/">Functionality</a>
+							<a class="toc-link" href="../functionality/autocomplete/">Functionality</a>
 													</div>
 																																				<div class="toc-item">
 							<a class="toc-link" href="../integrations/">Integrations</a>
@@ -132,15 +132,12 @@
 			</div>
 			
 			<main class="col-12 col-md-9 col-xl-8 py-md-3 pl-md-5" role="main">
-				<div class="alert alert-success mt-3" role="alert">
-					Version 1.0 has been released - See the <a href="https://space10-community.github.io/conversational-form/docs/">updated documentation</a>.
-				</div>
 				    <h1 id="public-api">Public API</h1>
     <p>When instantiating ConversationalForm a reference to the instance will be available in window scope.</p>
     
 	<pre><code class="language-javascript" data-lang="javascript">window.ConversationalForm</code></pre>
 	
-	<p>Be aware that if you create mutiple Conversational Forms within one page then the reference will be overwritten with latest created. Use windo.ConversationalForm[form["cf-create-id"]]?` or just manually instantiate the form and user the returned instance.</p>
+	<p>Be aware that if you create mutiple Conversational Forms within one page then the reference will be overwritten with latest created. Use window.ConversationalForm[form["cf-create-id"]]? or just manually instantiate the form and user the returned instance.</p>
 	
 	<table class="table compact">
     	<thead>
@@ -161,11 +158,6 @@
     		</tr>
 			<tr>
     			<td id="addTags">focus</td>
-    			<td>Sets focus on Conversational Form.</td>
-    			<td><pre><code class="language-javascript" data-lang="javascript">window.ConversationalForm.focus();</pre></code></td>
-    		</tr>
-    		<tr>
-    			<td id="focus">focus</td>
     			<td>Sets focus on Conversational Form.</td>
     			<td><pre><code class="language-javascript" data-lang="javascript">window.ConversationalForm.focus();</pre></code></td>
     		</tr>

--- a/docs/0.9.90/public-api/index.html
+++ b/docs/0.9.90/public-api/index.html
@@ -137,7 +137,7 @@
     
 	<pre><code class="language-javascript" data-lang="javascript">window.ConversationalForm</code></pre>
 	
-	<p>Be aware that if you create mutiple Conversational Forms within one page then the reference will be overwritten with latest created. Use window.ConversationalForm[form["cf-create-id"]]? or just manually instantiate the form and user the returned instance.</p>
+	<p>Be aware that if you create multiple Conversational Forms within one page then the reference will be overwritten with the latest created. Use window.ConversationalForm[form["cf-create-id"]]? or just manually instantiate the form and user the returned instance.</p>
 	
 	<table class="table compact">
     	<thead>

--- a/docs/1.0.0/public-api/index.html
+++ b/docs/1.0.0/public-api/index.html
@@ -137,7 +137,7 @@
     
 	<pre><code class="language-javascript" data-lang="javascript">window.ConversationalForm</code></pre>
 	
-	<p>Be aware that if you create mutiple Conversational Forms within one page then the reference will be overwritten with latest created. Use windo.ConversationalForm[form["cf-create-id"]]?` or just manually instantiate the form and user the returned instance.</p>
+	<p>Be aware that if you create mutiple Conversational Forms within one page then the reference will be overwritten with latest created. Use window.ConversationalForm[form["cf-create-id"]]? or just manually instantiate the form and user the returned instance.</p>
 	
 	<table class="table compact">
     	<thead>

--- a/docs/1.0.0/public-api/index.html
+++ b/docs/1.0.0/public-api/index.html
@@ -137,7 +137,7 @@
     
 	<pre><code class="language-javascript" data-lang="javascript">window.ConversationalForm</code></pre>
 	
-	<p>Be aware that if you create mutiple Conversational Forms within one page then the reference will be overwritten with latest created. Use window.ConversationalForm[form["cf-create-id"]]? or just manually instantiate the form and user the returned instance.</p>
+	<p>Be aware that if you create multiple Conversational Forms within one page then the reference will be overwritten with the latest created. Use window.ConversationalForm[form["cf-create-id"]]? or just manually instantiate the form and user the returned instance.</p>
 	
 	<table class="table compact">
     	<thead>


### PR DESCRIPTION
I fixed the following typos in the docs:

```diff
- Be aware that if you create mutiple Conversational Forms within one page then the reference will be overwritten with latest created. Use windo.ConversationalForm[form["cf-create-id"]]?` or just manually instantiate the form and user the returned instance.
+ Be aware that if you create multiple Conversational Forms within one page then the reference will be overwritten with the latest created. Use window.ConversationalForm[form["cf-create-id"]]? or just manually instantiate the form and user the returned instance.
```

This text should be wrapped in a pair of `<code></code>` tags, but I have not made this change because I do not know how it would/should be styled.

And why is there a question mark (`?`) at the end of the expression (`window.ConversationalForm[form["cf-create-id"]]?`)? Is it needed?